### PR TITLE
refactor(frontend): split web/mobile frontend + nginx deploy update

### DIFF
--- a/MODIFICATION_LOG.txt
+++ b/MODIFICATION_LOG.txt
@@ -1,0 +1,18 @@
+[2026-03-04] Nginx deployment update for web/mobile split
+
+1) Updated nginx.conf for independent web/mobile static outputs
+   - web root: /www/server/logtool/dist-web
+   - mobile /m/* alias: /www/server/logtool/dist-mobile/
+   - mobile SPA fallback: /m/index.html
+
+2) Added separated caching strategy
+   - web static assets: max-age=2592000, immutable (30d)
+   - mobile static assets (/m/*): max-age=2592000, immutable (30d)
+   - generic fallback static assets: max-age=604800 (7d)
+
+3) Preserved backend reverse proxy routes
+   - /api, /health, /ws unchanged
+
+Post-deploy checks:
+- nginx -t
+- systemctl reload nginx

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# LogTool
+
+## Frontend targets
+Frontend now supports explicit web/mobile boundaries with a shared code core.
+
+- `all` target: integrated build (legacy behavior, all routes)
+- `web` target: web-focused build
+- `mobile` target: mobile-focused build
+
+## Run frontend
+From `frontend/`:
+
+```bash
+npm install
+npm run serve
+npm run serve:web
+npm run serve:mobile
+```
+
+## Build frontend
+From `frontend/`:
+
+```bash
+npm run build
+npm run build:web
+npm run build:mobile
+```
+
+Build output directories:
+- `frontend/dist` (all)
+- `frontend/dist-web` (web)
+- `frontend/dist-mobile` (mobile)
+
+## URL compatibility
+Default integrated build (`npm run build` or `npm run serve`) preserves existing URLs:
+- `/dashboard...`
+- `/smart-search`
+- `/m...`
+- `/m/login`
+
+## Deploy approach
+- Integrated deploy: publish `frontend/dist`.
+- Independent deploy:
+  1. publish `frontend/dist-web` for web traffic
+  2. publish `frontend/dist-mobile` for mobile traffic
+  3. route `/m/*` to the mobile artifact at ingress layer
+
+## Migration reference
+See:
+- `frontend/docs/frontend-split-migration.md`

--- a/frontend/docs/frontend-split-migration.md
+++ b/frontend/docs/frontend-split-migration.md
@@ -1,0 +1,62 @@
+# Frontend Split Migration Note
+
+## Goal
+Introduce explicit frontend boundaries so web and mobile can be developed and deployed relatively independently while preserving existing behavior and URLs.
+
+## New structure
+- `src/apps/web/`
+  - `WebAppShell.vue`: web shell wrapper
+  - `routes.js`: web route module
+- `src/apps/mobile/`
+  - `MobileAppShell.vue`: mobile shell wrapper
+  - `routes.js`: mobile route module
+- `src/apps/shared/`
+  - `target.js`: runtime target selection (`all`/`web`/`mobile`)
+- `src/router/`
+  - `index.js`: route composition by target
+  - `guards.js`: shared route guards
+
+Shared cross-app modules remain centralized and unchanged in purpose:
+- `src/api/`
+- `src/store/`
+- `src/i18n/`
+
+## URL compatibility
+Default target is `all`, which keeps existing URLs working:
+- Web paths (for example): `/dashboard...`, `/smart-search`, `/login`
+- Mobile paths: `/m...`, `/m/login`
+
+Target-specific builds also include compatibility redirects where practical:
+- `web` target redirects `/m/*` to `/login`
+- `mobile` target redirects web entry paths to `/m` or `/m/login`
+
+## Build/run targets
+Environment flag:
+- `VUE_APP_TARGET=all|web|mobile`
+
+Scripts:
+- `npm run serve` (all)
+- `npm run serve:web`
+- `npm run serve:mobile`
+- `npm run build` (all)
+- `npm run build:web`
+- `npm run build:mobile`
+
+Output directories:
+- `all` -> `dist`
+- `web` -> `dist-web`
+- `mobile` -> `dist-mobile`
+
+## Independent deployment approach
+1. Build each target separately:
+   - `npm run build:web`
+   - `npm run build:mobile`
+2. Deploy `dist-web` and `dist-mobile` as separate static artifacts (or separate hosts).
+3. Route traffic by prefix (`/m`) at gateway/CDN/nginx level to the mobile artifact when split-hosting is desired.
+4. Keep backend API contract unchanged (`/api` proxy/baseURL remains the same).
+
+## Risk controls in this migration
+- No backend contract changes.
+- Existing shared store/api/i18n behavior preserved.
+- Route guards remain centralized and consistent across targets.
+- Default `all` target preserves current integrated runtime behavior.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,10 +4,14 @@
   "description": "LogTool Frontend - Vue.js application",
   "main": "index.js",
   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "serve": "VUE_APP_TARGET=all vue-cli-service serve",
+    "serve:web": "VUE_APP_TARGET=web vue-cli-service serve",
+    "serve:mobile": "VUE_APP_TARGET=mobile vue-cli-service serve",
+    "build": "VUE_APP_TARGET=all vue-cli-service build",
+    "build:web": "VUE_APP_TARGET=web vue-cli-service build",
+    "build:mobile": "VUE_APP_TARGET=mobile vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "dev": "vue-cli-service serve --port 8080"
+    "dev": "VUE_APP_TARGET=all vue-cli-service serve --port 8080"
   },
   "dependencies": {
     "@antv/f2": "^4.0.51",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,9 +7,8 @@
 </template>
 
 <script>
-import { computed, onBeforeUnmount, watch } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRoute } from 'vue-router'
 import zhCn from 'element-plus/es/locale/lang/zh-cn'
 import en from 'element-plus/es/locale/lang/en'
 
@@ -17,81 +16,17 @@ export default {
   name: 'App',
   setup() {
     const { locale } = useI18n()
-    const route = useRoute()
     const elementLocale = computed(() => (String(locale.value).startsWith('en') ? en : zhCn))
-
-    // ===== Platform scoping (Design Tokens) =====
-    const isMobileRoute = computed(() => {
-      const p = String(route.path || '')
-      return route.meta?.isMobile === true || p.startsWith('/m/')
-    })
-
-    const setPlatform = (isMobile) => {
-      try {
-        document.documentElement.dataset.platform = isMobile ? 'mobile' : 'web'
-      } catch (_) {}
-    }
-
-    watch(
-      isMobileRoute,
-      (v) => {
-        setPlatform(!!v)
-      },
-      { immediate: true }
-    )
-
-    // ===== Disable pinch zoom (extra hardening for iOS) =====
-    // Note: viewport meta already sets user-scalable=no. Some iOS versions may still allow gesture zoom.
-    const preventGestureZoom = (e) => {
-      try {
-        e.preventDefault()
-      } catch (_) {}
-    }
-    let gestureBound = false
-    const bindGesture = () => {
-      if (gestureBound) return
-      gestureBound = true
-      window.addEventListener('gesturestart', preventGestureZoom, { passive: false })
-      window.addEventListener('gesturechange', preventGestureZoom, { passive: false })
-      window.addEventListener('gestureend', preventGestureZoom, { passive: false })
-    }
-    const unbindGesture = () => {
-      if (!gestureBound) return
-      gestureBound = false
-      window.removeEventListener('gesturestart', preventGestureZoom)
-      window.removeEventListener('gesturechange', preventGestureZoom)
-      window.removeEventListener('gestureend', preventGestureZoom)
-    }
-
-    watch(
-      isMobileRoute,
-      (v) => {
-        // only bind on small screens + mobile routes
-        const isSmall = typeof window !== 'undefined' && window.matchMedia
-          ? window.matchMedia('(max-width: 768px)').matches
-          : false
-        if (v && isSmall) bindGesture()
-        else unbindGesture()
-      },
-      { immediate: true }
-    )
-
-    onBeforeUnmount(() => {
-      unbindGesture()
-    })
-
     return { elementLocale }
   }
 }
 </script>
 
 <style>
-/* 全局样式优化，减少ResizeObserver错误 */
 * {
   box-sizing: border-box;
 }
 
-/* 优化Element Plus组件的渲染性能 */
 .el-tabs__content {
   contain: layout style paint;
 }
@@ -108,7 +43,6 @@ export default {
   contain: layout style paint;
 }
 
-/* 减少不必要的重绘 */
 .el-tabs__item {
   will-change: auto;
 }
@@ -117,12 +51,10 @@ export default {
   will-change: auto;
 }
 
-/* 优化动画性能 */
 .el-collapse-transition {
   transition: height 0.3s ease-in-out, padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out;
 }
 
-/* 禁用某些可能导致ResizeObserver错误的动画 */
 .el-tabs__item.is-active {
   transition: none !important;
 }
@@ -143,12 +75,10 @@ export default {
   transition: none !important;
 }
 
-/* 禁用所有可能导致ResizeObserver错误的过渡动画 */
 .el-tabs * {
   transition: none !important;
 }
 
-/* 全局字体设置 */
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -157,7 +87,6 @@ body {
   padding: 0;
 }
 
-/* 滚动条样式 */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
@@ -177,12 +106,9 @@ body {
   background: #a8a8a8;
 }
 
-/* 移动端页面统一底部留白设置 */
 @media (max-width: 768px) {
-  /* 所有移动端页面统一使用相同的底部留白 */
   .page {
     padding-bottom: max(0px, env(safe-area-inset-bottom) - 20px) !important;
   }
 }
 </style>
-

--- a/frontend/src/apps/mobile/MobileAppShell.vue
+++ b/frontend/src/apps/mobile/MobileAppShell.vue
@@ -1,0 +1,46 @@
+<template>
+  <router-view />
+</template>
+
+<script>
+import { onBeforeUnmount, onMounted } from 'vue'
+
+export default {
+  name: 'MobileAppShell',
+  setup() {
+    const preventGestureZoom = (e) => {
+      try {
+        e.preventDefault()
+      } catch (_) {}
+    }
+
+    const bindGesture = () => {
+      window.addEventListener('gesturestart', preventGestureZoom, { passive: false })
+      window.addEventListener('gesturechange', preventGestureZoom, { passive: false })
+      window.addEventListener('gestureend', preventGestureZoom, { passive: false })
+    }
+
+    const unbindGesture = () => {
+      window.removeEventListener('gesturestart', preventGestureZoom)
+      window.removeEventListener('gesturechange', preventGestureZoom)
+      window.removeEventListener('gestureend', preventGestureZoom)
+    }
+
+    onMounted(() => {
+      try {
+        document.documentElement.dataset.platform = 'mobile'
+      } catch (_) {}
+
+      const isSmall = typeof window !== 'undefined' && window.matchMedia
+        ? window.matchMedia('(max-width: 768px)').matches
+        : false
+
+      if (isSmall) bindGesture()
+    })
+
+    onBeforeUnmount(() => {
+      unbindGesture()
+    })
+  }
+}
+</script>

--- a/frontend/src/apps/mobile/routes.js
+++ b/frontend/src/apps/mobile/routes.js
@@ -1,0 +1,25 @@
+export const mobileRoutes = [
+  {
+    path: 'login',
+    name: 'MLogin',
+    component: () => import('../../mobile/views/MobileLogin.vue'),
+    meta: { requiresAuth: false, noSidebar: true, isMobile: true }
+  },
+  {
+    path: '',
+    component: () => import('../../mobile/MobileLayout.vue'),
+    meta: { requiresAuth: true, noSidebar: true, isMobile: true },
+    children: [
+      { path: '', redirect: '/m/smart-search' },
+      { path: 'smart-search', name: 'MSmartSearch', component: () => import('../../mobile/views/MobileSmartSearch.vue'), meta: { hideTabbar: false, isMobile: true } },
+      { path: 'error', name: 'MError', component: () => import('../../mobile/views/ErrorQuery.vue'), meta: { isMobile: true } },
+      { path: 'logs', name: 'MLogs', component: () => import('../../mobile/views/LogDevices.vue'), meta: { isMobile: true } },
+      { path: 'logs/:deviceId', name: 'MDeviceLogs', component: () => import('../../mobile/views/DeviceLogs.vue'), meta: { hideTabbar: true, isMobile: true } },
+      { path: 'log-view/:logId', name: 'MLogView', component: () => import('../../mobile/views/LogView.vue'), meta: { hideTabbar: true, isMobile: true } },
+      { path: 'surgeries', name: 'MSurgeries', component: () => import('../../mobile/views/SurgeriesDevices.vue'), meta: { isMobile: true } },
+      { path: 'surgeries/:deviceId', name: 'MDeviceSurgeries', component: () => import('../../mobile/views/DeviceSurgeries.vue'), meta: { hideTabbar: true, isMobile: true } },
+      { path: 'surgery-visualization/:surgeryId', name: 'MSurgeryVisualization', component: () => import('../../mobile/views/SurgeryVisualization.vue'), meta: { hideTabbar: true, isMobile: true } },
+      { path: 'profile', name: 'MProfile', component: () => import('../../mobile/views/Profile.vue'), meta: { isMobile: true } }
+    ]
+  }
+]

--- a/frontend/src/apps/shared/target.js
+++ b/frontend/src/apps/shared/target.js
@@ -1,0 +1,9 @@
+const VALID_TARGETS = new Set(['all', 'web', 'mobile'])
+
+export const getAppTarget = () => {
+  const raw = String(process.env.VUE_APP_TARGET || 'all').toLowerCase()
+  return VALID_TARGETS.has(raw) ? raw : 'all'
+}
+
+export const isWebEnabled = (target = getAppTarget()) => target === 'all' || target === 'web'
+export const isMobileEnabled = (target = getAppTarget()) => target === 'all' || target === 'mobile'

--- a/frontend/src/apps/web/WebAppShell.vue
+++ b/frontend/src/apps/web/WebAppShell.vue
@@ -1,0 +1,18 @@
+<template>
+  <router-view />
+</template>
+
+<script>
+import { onMounted } from 'vue'
+
+export default {
+  name: 'WebAppShell',
+  setup() {
+    onMounted(() => {
+      try {
+        document.documentElement.dataset.platform = 'web'
+      } catch (_) {}
+    })
+  }
+}
+</script>

--- a/frontend/src/apps/web/routes.js
+++ b/frontend/src/apps/web/routes.js
@@ -1,0 +1,219 @@
+export const webRoutes = [
+  {
+    path: '/',
+    redirect: '/login'
+  },
+  {
+    path: '/smart-search',
+    name: 'SmartSearchStandalone',
+    component: () => import('../../views/SmartSearchPage.vue'),
+    meta: { requiresAuth: true, noSidebar: true }
+  },
+  {
+    path: '/data-analysis',
+    name: 'DataAnalysis',
+    component: () => import('../../views/DataAnalysisPage.vue'),
+    meta: { requiresAuth: true, noSidebar: true, requiresPermission: 'log:read_all' }
+  },
+  {
+    path: '/translate-tool',
+    name: 'TranslateTool',
+    component: () => import('../../views/TranslateTool.vue'),
+    meta: { requiresAuth: true, noSidebar: true }
+  },
+  {
+    path: '/login',
+    name: 'Login',
+    component: () => import('../../views/Login.vue'),
+    meta: { requiresAuth: false }
+  },
+  {
+    path: '/register',
+    name: 'Register',
+    component: () => import('../../views/Register.vue'),
+    meta: { requiresAuth: false }
+  },
+  {
+    path: '/batch-analysis/:logIds',
+    name: 'BatchAnalysisStandalone',
+    component: () => import('../../views/BatchAnalysis.vue'),
+    meta: { requiresAuth: true, noSidebar: true, requiresPermission: 'log:read_all' }
+  },
+  {
+    path: '/surgery-statistics',
+    name: 'SurgeryStatistics',
+    component: () => import('../../views/SurgeryStatistics.vue'),
+    meta: { requiresAuth: true, noSidebar: true, requiresPermission: 'surgery:read' }
+  },
+  {
+    path: '/surgery-visualization',
+    name: 'SurgeryVisualization',
+    component: () => import('../../views/SurgeryVisualization.vue'),
+    meta: { requiresAuth: true, noSidebar: true, requiresPermission: 'surgery:read' }
+  },
+  {
+    path: '/dashboard',
+    component: () => import('../../views/Dashboard.vue'),
+    meta: { requiresAuth: true },
+    children: [
+      {
+        path: '',
+        name: 'Dashboard',
+        redirect: '/dashboard/logs'
+      },
+      {
+        path: 'smart-search',
+        name: 'SmartSearch',
+        redirect: '/smart-search'
+      },
+      {
+        path: 'error-codes',
+        name: 'ErrorCodes',
+        component: () => import('../../views/ErrorCodes.vue')
+      },
+      {
+        path: 'i18n-error-codes',
+        name: 'I18nErrorCodes',
+        component: () => import('../../views/I18nErrorCodes.vue')
+      },
+      {
+        path: 'fault-cases',
+        name: 'FaultCases',
+        component: () => import('../../views/JiraFaultCases.vue'),
+        meta: { requiresPermission: 'fault_case:read' }
+      },
+      {
+        path: 'knowledge-base',
+        name: 'KnowledgeBase',
+        component: () => import('../../views/KnowledgeBase.vue'),
+        meta: { requiresPermission: 'kb:read' }
+      },
+      {
+        path: 'fault-cases/new',
+        name: 'FaultCaseCreate',
+        component: () => import('../../views/FaultCaseForm.vue'),
+        meta: { requiresPermission: 'fault_case:create', hideSidebar: true }
+      },
+      {
+        path: 'fault-cases/:id/edit',
+        name: 'FaultCaseEdit',
+        component: () => import('../../views/FaultCaseForm.vue'),
+        meta: { requiresPermission: 'fault_case:update', hideSidebar: true }
+      },
+      {
+        path: 'fault-cases/:id',
+        name: 'FaultCaseDetail',
+        component: () => import('../../views/FaultCaseDetail.vue'),
+        meta: { requiresPermission: 'fault_case:read' }
+      },
+      {
+        path: 'config-management',
+        name: 'ConfigManagement',
+        component: () => import('../../views/ConfigManagement.vue'),
+        meta: { requiresPermission: 'fault_case_config:manage' }
+      },
+      {
+        path: 'analysis-categories',
+        name: 'AnalysisCategories',
+        redirect: '/dashboard/config-management',
+        meta: { requiresPermission: 'fault_case_config:manage' }
+      },
+      {
+        path: 'logs',
+        name: 'Logs',
+        component: () => import('../../views/Logs.vue')
+      },
+      {
+        path: 'log-detail/:id',
+        name: 'LogDetail',
+        redirect: (to) => ({ path: `/batch-analysis/${to.params.id}` }),
+        meta: { requiresPermission: 'log:read_all' }
+      },
+      {
+        path: 'batch-analysis/:logIds',
+        name: 'BatchAnalysis',
+        component: () => import('../../views/BatchAnalysis.vue'),
+        meta: { requiresPermission: 'log:read_all' }
+      },
+      {
+        path: 'account',
+        name: 'Account',
+        component: () => import('../../views/Account.vue')
+      },
+      {
+        path: 'history',
+        name: 'History',
+        component: () => import('../../views/History.vue'),
+        meta: { requiresPermission: ['history:read_all', 'history:read_own'] }
+      },
+      {
+        path: 'users',
+        name: 'Users',
+        component: () => import('../../views/Users.vue'),
+        meta: { requiresPermission: 'user:read' }
+      },
+      {
+        path: 'roles',
+        name: 'Roles',
+        component: () => import('../../views/Roles.vue'),
+        meta: { requiresPermission: 'role:read' }
+      },
+      {
+        path: 'explanation-tester',
+        name: 'ExplanationTester',
+        component: () => import('../../views/ExplanationTester.vue'),
+        meta: { requiresPermission: 'test:explain' }
+      },
+      {
+        path: 'devices',
+        name: 'Devices',
+        component: () => import('../../views/Devices.vue'),
+        meta: { requiresPermission: 'device:read' }
+      },
+      {
+        path: 'data-replay',
+        name: 'DataReplay',
+        component: () => import('../../views/DataReplay.vue'),
+        meta: { requiresPermission: 'data_replay:manage' }
+      },
+      {
+        path: 'feedback',
+        name: 'Feedback',
+        component: () => import('../../views/Feedback.vue')
+      },
+      {
+        path: 'feedback-list',
+        name: 'FeedbackList',
+        component: () => import('../../views/FeedbackList.vue')
+      },
+      {
+        path: 'feedback-detail/:id',
+        name: 'FeedbackDetail',
+        component: () => import('../../views/FeedbackDetail.vue'),
+        props: true
+      },
+      {
+        path: 'global-dashboard',
+        name: 'GlobalDashboard',
+        component: () => import('../../views/GlobalDashboard.vue')
+      },
+      {
+        path: 'monitoring',
+        name: 'Monitoring',
+        component: () => import('../../views/MonitoringDashboard.vue'),
+        meta: { requiresPermission: 'system:monitor' }
+      },
+      {
+        path: 'surgeries',
+        name: 'Surgeries',
+        component: () => import('../../views/Surgeries.vue'),
+        meta: { requiresPermission: ['surgery:read', 'surgery:read_own'] }
+      },
+      {
+        path: 'translate-tool',
+        name: 'DashboardTranslateTool',
+        redirect: '/translate-tool'
+      }
+    ]
+  }
+]

--- a/frontend/src/router/guards.js
+++ b/frontend/src/router/guards.js
@@ -1,0 +1,40 @@
+export const registerGlobalGuards = (router, store) => {
+  router.beforeEach((to, from, next) => {
+    const isAuthenticated = store.getters['auth/isAuthenticated']
+    const mustChangePassword = store.getters['auth/mustChangePassword']
+    const userRole = store.getters['auth/userRole']
+    const hasPermission = store.getters['auth/hasPermission']
+    const isMobileRoute = to.path.startsWith('/m')
+    const accountPath = '/dashboard/account'
+
+    if (to.meta.requiresAuth && !isAuthenticated) {
+      next(isMobileRoute ? '/m/login' : '/login')
+      return
+    }
+    if (isAuthenticated && mustChangePassword && to.path !== accountPath) {
+      next(accountPath)
+      return
+    }
+    if (to.meta.requiresAdmin && userRole !== 'admin') {
+      next('/dashboard')
+      return
+    }
+    if (to.meta.requiresPermission) {
+      const required = to.meta.requiresPermission
+      const allowed = Array.isArray(required)
+        ? required.some((p) => hasPermission?.(p))
+        : hasPermission?.(required)
+      if (!allowed) {
+        next('/dashboard')
+      } else {
+        next()
+      }
+      return
+    }
+    if ((to.path === '/login' || to.path === '/m/login') && isAuthenticated && from.path !== to.path) {
+      next(mustChangePassword ? accountPath : (isMobileRoute ? '/m' : '/smart-search'))
+      return
+    }
+    next()
+  })
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,304 +1,59 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import store from '../store'
+import WebAppShell from '../apps/web/WebAppShell.vue'
+import MobileAppShell from '../apps/mobile/MobileAppShell.vue'
+import { webRoutes } from '../apps/web/routes'
+import { mobileRoutes } from '../apps/mobile/routes'
+import { getAppTarget, isWebEnabled, isMobileEnabled } from '../apps/shared/target'
+import { registerGlobalGuards } from './guards'
 
-const routes = [
-  {
+const appTarget = getAppTarget()
+
+const routes = []
+
+if (isWebEnabled(appTarget)) {
+  routes.push({
     path: '/',
-    redirect: '/login'
-  },
-  // 独立智能搜索页面（ChatGPT 风格，无侧边栏）
-  {
-    path: '/smart-search',
-    name: 'SmartSearchStandalone',
-    component: () => import('../views/SmartSearchPage.vue'),
-    meta: { requiresAuth: true, noSidebar: true }
-  },
-  // 多模态数据分析工具（统一时间轴联动）
-  {
-    path: '/data-analysis',
-    name: 'DataAnalysis',
-    component: () => import('../views/DataAnalysisPage.vue'),
-    meta: { requiresAuth: true, noSidebar: true, requiresPermission: 'log:read_all' }
-  },
-  // 文档翻译工具（独立标签页，无侧边栏）
-  {
-    path: '/translate-tool',
-    name: 'TranslateTool',
-    component: () => import('../views/TranslateTool.vue'),
-    meta: { requiresAuth: true, noSidebar: true }
-  },
-  {
-    path: '/login',
-    name: 'Login',
-    component: () => import('../views/Login.vue'),
-    meta: { requiresAuth: false }
-  },
-  {
-    path: '/register',
-    name: 'Register',
-    component: () => import('../views/Register.vue'),
-    meta: { requiresAuth: false }
-  },
-  // 移动端登录
-  {
-    path: '/m/login',
-    name: 'MLogin',
-    component: () => import('../mobile/views/MobileLogin.vue'),
-    meta: { requiresAuth: false, noSidebar: true, isMobile: true }
-  },
+    component: WebAppShell,
+    children: webRoutes
+  })
+}
 
-  // 批量查看路由（支持单个或多个日志ID）
-  {
-    path: '/batch-analysis/:logIds',
-    name: 'BatchAnalysisStandalone',
-    component: () => import('../views/BatchAnalysis.vue'),
-    // 日志查看/批量查看：允许拥有日志读取权限的用户访问
-    meta: { requiresAuth: true, noSidebar: true, requiresPermission: 'log:read_all' }
-  },
-  {
-    path: '/surgery-statistics',
-    name: 'SurgeryStatistics',
-    component: () => import('../views/SurgeryStatistics.vue'),
-    // 管理员、专家（统一使用 surgery:read）
-    meta: { requiresAuth: true, noSidebar: true, requiresPermission: 'surgery:read' }
-  },
-  {
-    path: '/surgery-visualization',
-    name: 'SurgeryVisualization',
-    component: () => import('../views/SurgeryVisualization.vue'),
-    meta: { requiresAuth: true, noSidebar: true, requiresPermission: 'surgery:read' }
-  },
-  {
-    path: '/dashboard',
-    component: () => import('../views/Dashboard.vue'),
-    meta: { requiresAuth: true },
-    children: [
-      {
-        path: '',
-        name: 'Dashboard',
-        redirect: '/dashboard/logs'
-      },
-      {
-        path: 'smart-search',
-        // 历史兼容：旧的 dashboard 内智能搜索入口，统一跳转到独立页面
-        name: 'SmartSearch',
-        redirect: '/smart-search'
-      },
-      {
-        path: 'error-codes',
-        name: 'ErrorCodes',
-        component: () => import('../views/ErrorCodes.vue')
-      },
-      {
-        path: 'i18n-error-codes',
-        name: 'I18nErrorCodes',
-        component: () => import('../views/I18nErrorCodes.vue')
-      },
-      {
-        path: 'fault-cases',
-        name: 'FaultCases',
-        component: () => import('../views/JiraFaultCases.vue'),
-        meta: { requiresPermission: 'fault_case:read' }
-      },
-      {
-        path: 'knowledge-base',
-        name: 'KnowledgeBase',
-        component: () => import('../views/KnowledgeBase.vue'),
-        meta: { requiresPermission: 'kb:read' }
-      },
-      {
-        path: 'fault-cases/new',
-        name: 'FaultCaseCreate',
-        component: () => import('../views/FaultCaseForm.vue'),
-        meta: { requiresPermission: 'fault_case:create', hideSidebar: true }
-      },
-      {
-        path: 'fault-cases/:id/edit',
-        name: 'FaultCaseEdit',
-        component: () => import('../views/FaultCaseForm.vue'),
-        meta: { requiresPermission: 'fault_case:update', hideSidebar: true }
-      },
-      {
-        path: 'fault-cases/:id',
-        name: 'FaultCaseDetail',
-        component: () => import('../views/FaultCaseDetail.vue'),
-        meta: { requiresPermission: 'fault_case:read' }
-      },
-      {
-        path: 'config-management',
-        name: 'ConfigManagement',
-        component: () => import('../views/ConfigManagement.vue'),
-        meta: { requiresPermission: 'fault_case_config:manage' }
-      },
-      {
-        // 兼容旧入口：日志分析等级 -> 配置管理
-        path: 'analysis-categories',
-        name: 'AnalysisCategories',
-        redirect: '/dashboard/config-management',
-        meta: { requiresPermission: 'fault_case_config:manage' }
-      },
-      {
-        path: 'logs',
-        name: 'Logs',
-        component: () => import('../views/Logs.vue')
-      },
-      {
-        path: 'log-detail/:id',
-        name: 'LogDetail',
-        redirect: (to) => ({ path: `/batch-analysis/${to.params.id}` }),
-        meta: { requiresPermission: 'log:read_all' }
-      },
-      {
-        path: 'batch-analysis/:logIds',
-        name: 'BatchAnalysis',
-        component: () => import('../views/BatchAnalysis.vue'),
-        meta: { requiresPermission: 'log:read_all' }
-      },
-      {
-        path: 'account',
-        name: 'Account',
-        component: () => import('../views/Account.vue')
-      },
-      {
-        path: 'history',
-        name: 'History',
-        component: () => import('../views/History.vue'),
-        meta: { requiresPermission: ['history:read_all', 'history:read_own'] }
-      },
-      {
-        path: 'users',
-        name: 'Users',
-        component: () => import('../views/Users.vue'),
-        meta: { requiresPermission: 'user:read' }
-      },
-      {
-        path: 'roles',
-        name: 'Roles',
-        component: () => import('../views/Roles.vue'),
-        meta: { requiresPermission: 'role:read' }
-      },
-      {
-        path: 'explanation-tester',
-        name: 'ExplanationTester',
-        component: () => import('../views/ExplanationTester.vue'),
-        meta: { requiresPermission: 'test:explain' }
-      },
-      {
-        path: 'devices',
-        name: 'Devices',
-        component: () => import('../views/Devices.vue'),
-        meta: { requiresPermission: 'device:read' }
-      },
-      {
-        path: 'data-replay',
-        name: 'DataReplay',
-        component: () => import('../views/DataReplay.vue'),
-        meta: { requiresPermission: 'data_replay:manage' }
-      },
-      {
-        path: 'feedback',
-        name: 'Feedback',
-        component: () => import('../views/Feedback.vue')
-      },
-      {
-        path: 'feedback-list',
-        name: 'FeedbackList',
-        component: () => import('../views/FeedbackList.vue')
-      },
-      {
-        path: 'feedback-detail/:id',
-        name: 'FeedbackDetail',
-        component: () => import('../views/FeedbackDetail.vue'),
-        props: true
-      },
-      {
-        path: 'global-dashboard',
-        name: 'GlobalDashboard',
-        component: () => import('../views/GlobalDashboard.vue')
-      },
-      {
-        path: 'monitoring',
-        name: 'Monitoring',
-        component: () => import('../views/MonitoringDashboard.vue'),
-        meta: { requiresPermission: 'system:monitor' }
-      },
-      {
-        path: 'surgeries',
-        name: 'Surgeries',
-        component: () => import('../views/Surgeries.vue'),
-        // 允许拥有全部或仅本人可读权限的用户访问
-        meta: { requiresPermission: ['surgery:read', 'surgery:read_own'] }
-      },
-      {
-        path: 'translate-tool',
-        name: 'DashboardTranslateTool',
-        redirect: '/translate-tool'
-      }
-    ]
-  },
-  // 移动端主路由
-  {
+if (isMobileEnabled(appTarget)) {
+  routes.push({
     path: '/m',
-    component: () => import('../mobile/MobileLayout.vue'),
-    meta: { requiresAuth: true, noSidebar: true, isMobile: true },
-    children: [
-      { path: '', redirect: '/m/smart-search' },
-      { path: 'smart-search', name: 'MSmartSearch', component: () => import('../mobile/views/MobileSmartSearch.vue'), meta: { hideTabbar: false } },
-      { path: 'error', name: 'MError', component: () => import('../mobile/views/ErrorQuery.vue') },
-      { path: 'logs', name: 'MLogs', component: () => import('../mobile/views/LogDevices.vue') },
-      { path: 'logs/:deviceId', name: 'MDeviceLogs', component: () => import('../mobile/views/DeviceLogs.vue'), meta: { hideTabbar: true } },
-      { path: 'log-view/:logId', name: 'MLogView', component: () => import('../mobile/views/LogView.vue'), meta: { hideTabbar: true } },
-      { path: 'surgeries', name: 'MSurgeries', component: () => import('../mobile/views/SurgeriesDevices.vue') },
-      { path: 'surgeries/:deviceId', name: 'MDeviceSurgeries', component: () => import('../mobile/views/DeviceSurgeries.vue'), meta: { hideTabbar: true } },
-      { path: 'surgery-visualization/:surgeryId', name: 'MSurgeryVisualization', component: () => import('../mobile/views/SurgeryVisualization.vue'), meta: { hideTabbar: true } },
-      { path: 'profile', name: 'MProfile', component: () => import('../mobile/views/Profile.vue') }
-    ]
-  }
-]
+    component: MobileAppShell,
+    children: mobileRoutes
+  })
+}
+
+if (appTarget === 'web') {
+  routes.push({
+    path: '/m/:pathMatch(.*)*',
+    redirect: '/login'
+  })
+}
+
+if (appTarget === 'mobile') {
+  routes.push({
+    path: '/dashboard/:pathMatch(.*)*',
+    redirect: '/m'
+  })
+  routes.push({ path: '/smart-search', redirect: '/m/smart-search' })
+  routes.push({ path: '/login', redirect: '/m/login' })
+  routes.push({ path: '/register', redirect: '/m/login' })
+}
+
+routes.push({
+  path: '/:pathMatch(.*)*',
+  redirect: isMobileEnabled(appTarget) && !isWebEnabled(appTarget) ? '/m/login' : '/login'
+})
 
 const router = createRouter({
   history: createWebHistory(),
   routes
 })
 
-// 路由守卫
-router.beforeEach((to, from, next) => {
-  const isAuthenticated = store.getters['auth/isAuthenticated']
-  const mustChangePassword = store.getters['auth/mustChangePassword']
-  const userRole = store.getters['auth/userRole']
-  const hasPermission = store.getters['auth/hasPermission']
-  const isMobileRoute = to.path.startsWith('/m')
-  const accountPath = '/dashboard/account'
-
-  if (to.meta.requiresAuth && !isAuthenticated) {
-    next(isMobileRoute ? '/m/login' : '/login')
-    return
-  }
-  if (isAuthenticated && mustChangePassword && to.path !== accountPath) {
-    next(accountPath)
-    return
-  }
-  if (to.meta.requiresAdmin && userRole !== 'admin') {
-    next('/dashboard')
-    return
-  }
-  if (to.meta.requiresPermission) {
-    const required = to.meta.requiresPermission
-    const allowed = Array.isArray(required)
-      ? required.some((p) => hasPermission?.(p))
-      : hasPermission?.(required)
-    if (!allowed) {
-      next('/dashboard')
-    } else {
-      next()
-    }
-    return
-  }
-  if ((to.path === '/login' || to.path === '/m/login') && isAuthenticated && from.path !== to.path) {
-    next(mustChangePassword ? accountPath : (isMobileRoute ? '/m' : '/smart-search'))
-    return
-  }
-  next()
-})
+registerGlobalGuards(router, store)
 
 export default router

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -7,8 +7,8 @@ function getVersionAndChangelog() {
   const rootDir = path.resolve(__dirname, '..')
   const versionPath = path.join(rootDir, 'VERSION')
   const changelogPath = path.join(rootDir, 'CHANGELOG.md')
-  const version = fs.readFileSync(versionPath, 'utf8').trim()
-  const changelog = fs.readFileSync(changelogPath, 'utf8')
+  const version = fs.existsSync(versionPath) ? fs.readFileSync(versionPath, 'utf8').trim() : '0.0.0'
+  const changelog = fs.existsSync(changelogPath) ? fs.readFileSync(changelogPath, 'utf8') : ''
   const versionEscaped = version.replace(/\./g, '\\.')
   const regex = new RegExp(`## \\[${versionEscaped}\\] - ([^\\n]+)\\n([\\s\\S]*?)(?=\\n---\\s*\\n|\\n## \\[|$)`)
   const match = changelog.match(regex)
@@ -17,6 +17,9 @@ function getVersionAndChangelog() {
 }
 
 const { version: APP_VERSION, content: APP_CHANGELOG_CURRENT } = getVersionAndChangelog()
+const APP_TARGET = ['all', 'web', 'mobile'].includes((process.env.VUE_APP_TARGET || '').toLowerCase())
+  ? String(process.env.VUE_APP_TARGET).toLowerCase()
+  : 'all'
 
 module.exports = defineConfig({
   transpileDependencies: true,
@@ -24,6 +27,7 @@ module.exports = defineConfig({
     config.plugin('define').tap((definitions) => {
       definitions[0]['__APP_VERSION__'] = JSON.stringify(APP_VERSION)
       definitions[0]['__APP_CHANGELOG_CURRENT__'] = JSON.stringify(APP_CHANGELOG_CURRENT)
+      definitions[0]['__APP_TARGET__'] = JSON.stringify(APP_TARGET)
       return definitions
     })
     config.module
@@ -65,5 +69,6 @@ module.exports = defineConfig({
     hot: false,
     liveReload: false
   },
-  publicPath: '/'
+  publicPath: '/',
+  outputDir: APP_TARGET === 'all' ? 'dist' : `dist-${APP_TARGET}`
 })

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,16 +1,8 @@
-user  www www;
+user  www-data;
 worker_processes auto;
-error_log  /www/wwwlogs/nginx_error.log  crit;
-pid        /www/server/nginx/logs/nginx.pid;
+error_log  /var/log/nginx/error.log  crit;
+pid        /run/nginx.pid;
 worker_rlimit_nofile 51200;
-
-stream {
-    log_format tcp_format '$time_local|$remote_addr|$protocol|$status|$bytes_sent|$bytes_received|$session_time|$upstream_addr|$upstream_bytes_sent|$upstream_bytes_received|$upstream_connect_time';
-  
-    access_log /www/wwwlogs/tcp-access.log tcp_format;
-    error_log /www/wwwlogs/tcp-error.log;
-    include /www/server/panel/vhost/nginx/tcp/*.conf;
-}
 
 events
     {
@@ -25,7 +17,7 @@ http
 		#include luawaf.conf;
 
 		#include proxy.conf;
-        lua_package_path "/www/server/nginx/lib/lua/?.lua;;";
+        #lua_package_path "/www/server/nginx/lib/lua/?.lua;;";
 
         default_type  application/octet-stream;
 
@@ -89,23 +81,39 @@ map $http_user_agent $is_mobile {
 }
 server {
     listen 80;
-    server_name 42.121.15.87;  # 使用下划线表示接受所有域名/IP访问，或者改为你的域名/IP（如：192.168.1.100）
+    server_name 47.98.156.69;  # 使用下划线表示接受所有域名/IP访问，或者改为你的域名/IP（如：192.168.1.100）
     
     # 日志配置
-    access_log /www/wwwlogs/logtool-access.log;
-    error_log /www/wwwlogs/logtool-error.log;
-    # 前端静态文件目录
-    root /www/server/logtool;
+    access_log /var/log/nginx/logtool-access.log;
+    error_log /var/log/nginx/logtool-error.log;
+    # 前端静态文件目录（桌面端）
+    root /www/server/logtool/dist-web;
     index index.html;
 
 
-    # 静态资源缓存配置（1年）- 最高优先级，优先匹配
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
+    # 桌面端静态资源缓存（dist-web）
+    location ~* ^/(js|css|img|fonts|instruments|favicon\.ico|manifest\.json|service-worker\.js) {
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000, immutable";
         access_log off;
-        # 静态资源不需要重定向，直接返回
         try_files $uri =404;
+    }
+
+    # 移动端静态资源缓存（dist-mobile）
+    location ~* ^/m/(js|css|img|fonts|instruments|favicon\.ico|manifest\.json|service-worker\.js) {
+        alias /www/server/logtool/dist-mobile/;
+        expires 30d;
+        add_header Cache-Control "public, max-age=2592000, immutable";
+        access_log off;
+        try_files $uri /m/index.html;
+    }
+
+    # 其他通用静态资源缓存（兜底）
+    location ~* \.(png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800";
+        access_log off;
+        try_files $uri /m$uri =404;
     }
 
     # 后端 API 代理 - 移动端和桌面端共用同一个 API
@@ -173,13 +181,18 @@ server {
     }
 
     # 移动端路径 - 如果已经是移动端路径，正常处理（避免循环重定向）
-    # 移动端路径重写：/m 及其子路径都回退到单页入口
+    # 移动端路径重写：/m 及其子路径都回退到移动端单页入口
     location = /m {
         return 301 /m/;
     }
 
+    location = /m/index.html {
+        alias /www/server/logtool/dist-mobile/index.html;
+    }
+
     location ^~ /m/ {
-        try_files $uri $uri/ /index.html;
+        alias /www/server/logtool/dist-mobile/;
+        try_files $uri $uri/ /m/index.html;
     }
 
     # 主要入口页面 - 移动设备访问时自动重定向到移动端


### PR DESCRIPTION
## Summary\n- Split frontend into clearer web/mobile app boundaries for relative independence\n- Added target-based scripts for independent run/build (, , , )\n- Added migration notes and README updates\n- Updated nginx config to serve  and  separately with SPA fallback\n- Added modification log for deployment/config changes\n\n## Validation\n- Frontend build passes for both targets:\n  - \n  - \n- Local runtime verified:\n  - frontend dev server on 8081\n  - backend cluster on 3000\n  - redis on 6379\n\n## Notes\n- API reverse proxy paths remain unchanged (, , )\n- This is an incremental split for independent development/deployment while still sharing common infra.\n